### PR TITLE
Fixed: Resend button didn't appear

### DIFF
--- a/apps/web/app/page.client.test.tsx
+++ b/apps/web/app/page.client.test.tsx
@@ -324,7 +324,7 @@ describe("PageClient", () => {
 
   test("TEST#6: should render resend button", () => {
     vi.mocked(useRegisterResend).mockReturnValue({
-      tab: "resend",
+      tab: "resend-instruction",
       data: { name: "", phone: "" },
       errors: {
         register: "",
@@ -346,7 +346,7 @@ describe("PageClient", () => {
 
   test("TEST#6.2: should render resend button with loading state", () => {
     vi.mocked(useRegisterResend).mockReturnValue({
-      tab: "resend",
+      tab: "resend-instruction",
       data: { name: "", phone: "" },
       errors: {
         register: "",
@@ -372,7 +372,7 @@ describe("PageClient", () => {
   test("TEST#6.1: should call handleResend when resend button is clicked", () => {
     const handleResend = vi.fn();
     vi.mocked(useRegisterResend).mockReturnValue({
-      tab: "resend",
+      tab: "resend-instruction",
       data: { name: "", phone: "" },
       errors: {
         register: "",

--- a/apps/web/app/page.client.tsx
+++ b/apps/web/app/page.client.tsx
@@ -7,12 +7,13 @@ import { faTimesCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Button from "@/components/button";
 import { useCallback } from "react";
+import { Tab } from "@/hooks/use-home-tab";
 
 const countryCodePhoneErrorMessage =
   "Phone must starts with valid country code";
 
 interface PageClientFormProps {
-  tab: "register" | "resend" | "test-webhook";
+  tab: Tab;
   data: {
     name: string;
     phone: string;
@@ -91,7 +92,7 @@ export const PageClientForm = ({
         </Button>
       )}
       {/* TEST#6 */}
-      {tab === "resend" && (
+      {tab === "resend-instruction" && (
         <Button
           data-testid="resend-button"
           disabled={isPendingResend}

--- a/apps/web/hooks/use-register-resend.test.ts
+++ b/apps/web/hooks/use-register-resend.test.ts
@@ -26,6 +26,7 @@ vi.mock("@/actions/resend/action", () => ({
 
 describe("useRegisterResend", () => {
   afterEach(() => {
+    vi.resetAllMocks();
     vi.clearAllMocks();
   });
 
@@ -263,5 +264,26 @@ describe("useRegisterResend", () => {
     const errors = validateData(data, "register");
 
     expect(errors).toBeUndefined();
+  });
+
+  test("TEST#12: should clear errors when the tab changes", async () => {
+    const { result, rerender } = renderHook(() => useRegisterResend());
+
+    await act(async () => {
+      result.current.setErrorForKey("register", "Register error");
+    });
+
+    expect(result.current.errors.register).toBe("Register error");
+
+    vi.mocked(useSearchParams).mockReturnValue({
+      get: (_key: string) => {
+        return "resend-instruction";
+      },
+    } as ReadonlyURLSearchParams);
+
+    // trigger the useEffect by re-rendering the hook
+    rerender();
+
+    expect(result.current.errors.register).toBe("");
   });
 });

--- a/apps/web/hooks/use-register-resend.test.ts
+++ b/apps/web/hooks/use-register-resend.test.ts
@@ -235,13 +235,13 @@ describe("useRegisterResend", () => {
     vi.mocked(useSearchParams).mockReturnValue({
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       get: (_key: string) => {
-        return "resend";
+        return "resend-instruction";
       },
     } as ReadonlyURLSearchParams);
 
     const { result } = renderHook(() => useRegisterResend());
 
-    expect(result.current.tab).toBe("resend");
+    expect(result.current.tab).toBe("resend-instruction");
   });
 
   test("TEST#9: validateData should return error when name is less than 3 characters ", async () => {

--- a/apps/web/hooks/use-register-resend.ts
+++ b/apps/web/hooks/use-register-resend.ts
@@ -1,7 +1,13 @@
 import { register } from "@/actions/register/action";
 import { resend } from "@/actions/resend/action";
 import { useSearchParams } from "next/navigation";
-import { useCallback, useMemo, useState, useTransition } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useTransition,
+} from "react";
 import { Tab } from "./use-home-tab";
 
 export const validateData = (
@@ -93,6 +99,12 @@ export const useRegisterResend = () => {
 
   // TEST#7
   const tab = (searchParams.get("tab") as Tab) ?? "register";
+
+  // TEST#12
+  useEffect(() => {
+    // When the tab changes, clear the errors
+    clearErrors();
+  }, [tab]);
 
   // TEST#5
   const handleRegister = useCallback(async () => {

--- a/apps/web/hooks/use-register-resend.ts
+++ b/apps/web/hooks/use-register-resend.ts
@@ -2,10 +2,11 @@ import { register } from "@/actions/register/action";
 import { resend } from "@/actions/resend/action";
 import { useSearchParams } from "next/navigation";
 import { useCallback, useMemo, useState, useTransition } from "react";
+import { Tab } from "./use-home-tab";
 
 export const validateData = (
   data: { name: string; phone: string },
-  tab: "register" | "resend" | "test-webhook"
+  tab: Tab
 ):
   | {
       name: string;
@@ -91,9 +92,7 @@ export const useRegisterResend = () => {
   const searchParams = useSearchParams();
 
   // TEST#7
-  const tab =
-    (searchParams.get("tab") as "register" | "resend" | "test-webhook") ??
-    "register";
+  const tab = (searchParams.get("tab") as Tab) ?? "register";
 
   // TEST#5
   const handleRegister = useCallback(async () => {


### PR DESCRIPTION
Resolves #2 

The bug happened because of the different tab's string in `useRegisterResend` hook and the `useHomeTab` hook for the resend tab. 

- This PR fixed it by making them all the same with type safety.
- The error message is also cleared when the tab changes.